### PR TITLE
feat: add travis builds, various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+node_js:
+  - "7"
+
+sudo: false
+notifications:
+  email: false
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
+install:
+  - yarn
+
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gulp-resource-hints
 > Add resource hints to your html files
 
+[![Build Status](https://travis-ci.org/theetrain/gulp-resource-hints.svg?branch=master)](https://travis-ci.org/theetrain/gulp-resource-hints)
+
 ## Introduction
 
 [Resource hints](https://www.w3.org/TR/resource-hints/) are a great way to reduce loading times on your progressive website. At the time of this writing, only Chrome has support for the major resource hints, but `prefetch` and `dns-prefetch` have [fairly wide availability](http://caniuse.com/#search=resource%20hints) among browsers. Further reading [here](https://medium.com/@luisvieira_gmr/html5-prefetch-1e54f6dda15d).

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,9 +1,12 @@
 const isCSS = require('is-css')
 const minimatch = require('minimatch')
-const defaults = require('./defaults')
 const Soup = require('soup')
+const gutil = require('gulp-util')
 const parse = require('url').parse
 
+const defaults = require('./defaults')
+
+const PLUGIN_NAME = 'gulp-resource-hints'
 var parsedAssets = []
 
 var fonts = [
@@ -49,6 +52,11 @@ function globMatch (file, globs) {
     }
   }
 }
+
+function clearParsedAssets () {
+  parsedAssets = []
+}
+module.exports.clearParsedAssets = clearParsedAssets
 
 /**
  * Checking duplicates is necessary for dns-prefetch and prefetch
@@ -99,7 +107,7 @@ module.exports.buildResourceHint = buildResourceHint
 function mergeOptions (userOpts) {
   // iterate over existing keys
 
-  var options
+  var options = {}
 
   if (!userOpts) {
     return defaults
@@ -132,7 +140,7 @@ function writeData (file, data, token) {
   }
 
   if (token !== '' && token !== defaults.pageToken) {
-    console.warn('Provided token was not found')
+    gutil.log(PLUGIN_NAME, 'Provided token was not found in: ' + file.relative + '\nWill attempt to append to <head>')
   }
   var soup = new Soup(String(file.contents))
   var hasMeta = false
@@ -163,7 +171,7 @@ function writeData (file, data, token) {
 
   // No head? Oh noes!
   if (!hasHead) {
-    console.warn('No document <head> found, cannot write resource hints. Skipping file:', file.relative)
+    gutil.log(PLUGIN_NAME, 'No document <head> found, cannot write resource hints. Skipping file:', file.relative)
     return false
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var listAssets = require('list-assets')
-var gutil = require('gulp-util')
-var Transform = require('stream').Transform
+const listAssets = require('list-assets')
+const gutil = require('gulp-util')
+const Transform = require('stream').Transform
 
+const PLUGIN_NAME = 'gulp-resource-hints'
 var helpers = require('./helpers')
-// const PLUGIN_NAME = 'gulp-resource-hints'
 
 function gulpResourceHints (opt) {
   var options = helpers.mergeOptions(opt)
@@ -14,7 +14,7 @@ function gulpResourceHints (opt) {
     objectMode: true,
     transform: function (file, enc, cb) {
       if (file.isNull()) {
-        gutil.log('no file')
+        gutil.log(PLUGIN_NAME, 'no file')
 
         cb(null, file)
         return
@@ -32,6 +32,13 @@ function gulpResourceHints (opt) {
       ).map((ob) => {
         return ob.url
       })
+
+      if (assets.length < 0) {
+        cb(null, file)
+        return
+      }
+
+      helpers.clearParsedAssets()
 
       // Future feature! Gotta do more stream madness
       // if (options.getCSSAssets) {

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -43,7 +43,24 @@ gulp.task('defaultTest', function (cb) {
     })
     .on('error', () => {
       gutil.log()
-      tap.fail('Default Test: Error on stream')
+      tap.fail(testName, 'Error on stream')
+    })
+})
+
+gulp.task('userOptionsTest', function (cb) {
+  const testName = 'User Options Test'
+
+  return gulp.src('./fixtures/*(.html)!(*-result.html)')
+    .pipe(resourceHints({
+      pageToken: 'happyTime'
+    }))
+    .pipe(gulp.dest('./results'))
+    .on('end', () => {
+      tap.pass('Default Test: Pass')
+    })
+    .on('error', () => {
+      gutil.log()
+      tap.fail(testName, 'Error on stream')
     })
 })
 
@@ -53,5 +70,5 @@ gulp.task('clean', function (cb) {
 })
 
 gulp.task('default', function (cb) {
-  sequence('clean', 'defaultTest')
+  sequence('clean', 'defaultTest', 'userOptionsTest')
 })


### PR DESCRIPTION
Closes #5 

- clear parsedAssets array at the beginning of every stream. Assets were checked for duplicates across all html files, which may not be what the user wants.
- fix user options, custom page tokens weren't being accepted previously
- leverage gutil in the helpers
- add user-defined options as a test